### PR TITLE
Add Wrapper class import to usdm_model init file in order to allow for importing class as package user

### DIFF
--- a/src/usdm_model/__init__.py
+++ b/src/usdm_model/__init__.py
@@ -50,6 +50,7 @@ from .syntax_template import *
 from .syntax_template_dictionary import *
 from .timing import *
 from .transition_rule import *
+from .wrapper import *
 
 __all__ = [
   'Abbreviation',


### PR DESCRIPTION
Users that set usdm as a dependency python package will be able to import the Wrapper class in their source code, allowing for using the mentioned class to wrap studies and add info on usdm version.

The class is already included in the __all__ list, but the import is missing: when actually importing the class into other source code the import would fail.