### PR TITLE
Add InterventionalStudyDesign and ObservationalStudyDesign classes import to usdm_model init file in order to allow for importing classes as package user

### DIFF
--- a/src/usdm_model/__init__.py
+++ b/src/usdm_model/__init__.py
@@ -45,7 +45,7 @@ from .study_amendment import StudyAmendment
 from .study_amendment_reason import StudyAmendmentReason
 from .study_arm import StudyArm
 from .study_cell import StudyCell
-from .study_design import StudyDesign
+from .study_design import InterventionalStudyDesign, ObservationalStudyDesign, StudyDesign
 from .study_element import StudyElement
 from .study_epoch import StudyEpoch
 from .identifier import (
@@ -102,10 +102,12 @@ __all__ = [
     "Indication",
     "Ingredient",
     "IntercurrentEvent",
+    "InterventionalStudyDesign",
     "Masking",
     "NarrativeContent",
     "NarrativeContentItem",
     "Objective",
+    "ObservationalStudyDesign",
     "Organization",
     "Procedure",
     "Quantity",


### PR DESCRIPTION
This PR adds InterventionalStudyDesign and ObservationalStudyDesign classes import to usdm_model init file and classes names to __all__ list in order to allow for importing classes as package user.